### PR TITLE
ci: fix deploy (Node 22) and ship Astro site to production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
Fixes the broken GitHub Pages deploy and ships the Astro site live.

The deploy workflow pinned Node 20, but Astro 6 needs Node >=22.12, so every run since the Astro upgrade failed at build and `gh-pages` was frozen on the March-2024 React build. This bumps the workflow to Node 22 so the merge push actually deploys the current site (including the Dhan MCP Server card just merged in #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)