### PR TITLE
ci: deploy via GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -28,6 +31,9 @@ jobs:
         run: npm run build
 
       - name: Deploy with gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git remote set-url origin https://git:${{secrets.PAT}}@github.com/${{github.repository}}.git
-          npx gh-pages -d dist -u "github-actions-bot <support+actions@github.com>"
+          npx gh-pages -d dist \
+            -u "github-actions-bot <support+actions@github.com>" \
+            -r "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
Replaces the expired PAT secret with the built-in GITHUB_TOKEN (contents:write) so the gh-pages push authenticates. Final piece to get the Astro site live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)